### PR TITLE
Fix yaml.load warnings.

### DIFF
--- a/mirage_linemode/config.py
+++ b/mirage_linemode/config.py
@@ -37,7 +37,7 @@ def get_config(config_path):
     src = deepcopy(default_config)
     try:
         with open(config_path, 'r') as fp:
-            config = mix_dict(src, yaml.load(fp))
+            config = mix_dict(src, yaml.load(fp, Loader=yaml.FullLoader))
     except (OSError, IOError, TypeError, yaml.YAMLError):
         config = src
     # except:

--- a/mirage_linemode/theme/core.py
+++ b/mirage_linemode/theme/core.py
@@ -98,7 +98,7 @@ def get_theme(theme_path):
     src = deepcopy(theme_skelton)
     try:
         with open(theme_path, 'r') as fp:
-            theme = mix_dict(src, yaml.load(fp))
+            theme = mix_dict(src, yaml.load(fp, Loader=yaml.FullLoader))
     except (OSError, IOError, TypeError, yaml.YAMLError):
         theme = mix_dict(src, default_theme)
     # except:

--- a/mirage_linemode/theme/icon_width_list.py
+++ b/mirage_linemode/theme/icon_width_list.py
@@ -65,7 +65,7 @@ def isicon(v):
 def print_list(theme_filename):
     try:
         with open(theme_filename, 'r') as fp:
-            theme = yaml.load(fp)
+            theme = yaml.load(fp, Loader=yaml.FullLoader)
     except (OSError, IOError, yaml.YAMLError):
         theme = {'icon': {}}
     theme_icon = theme['icon']


### PR DESCRIPTION
yaml.load now warns if a Loader wasn't specified. This pull request fixes those warnings.